### PR TITLE
Only load frontend assets when required

### DIFF
--- a/accordion-blocks.php
+++ b/accordion-blocks.php
@@ -103,13 +103,15 @@ class PB_Accordion_Blocks {
 	public function enqueue_frontend_assets() {
 		$min = (defined('SCRIPT_DEBUG') && SCRIPT_DEBUG) ? '' : '.min';
 
-		wp_enqueue_script(
-			'pb-accordion-blocks-frontend-script',
-			plugins_url("js/accordion-blocks$min.js", __FILE__),
-			array('jquery'),
-			$this->plugin_version,
-			true
-		);
+		if (has_block('pb/accordion-item', get_the_ID())) {
+			wp_enqueue_script(
+				'pb-accordion-blocks-frontend-script',
+				plugins_url("js/accordion-blocks$min.js", __FILE__),
+				array('jquery'),
+				$this->plugin_version,
+				true
+			);
+		}
 	}
 
 


### PR DESCRIPTION
Currently the frontend asset are loaded on all pages. With this change the files will only be loaded on pages where the accordion block is used.