### PR TITLE
Replace window.onload with $(document).ready()

### DIFF
--- a/js/accordion-blocks.js
+++ b/js/accordion-blocks.js
@@ -318,7 +318,7 @@
 
 	// Loop through accordion settings objects
 	// Wait for the entire page to load before loading the accordion
-	$(window).on('load', function() {
+	$(document).ready( function() {
 		$('.js-accordion-item').each(function() {
 			$(this).accordionBlockItem({
 				// Set default settings


### PR DESCRIPTION
The window onload event waits until all images in the document finish loading.
This causes there to be a long wait time between when accordions display and when accordions are functions.
DOMReady is a more appropriate event — this fires when the page HTML and JavaScripted is parsed and ready for manipulation.
This change causes accordions to be functional immediately.