### PR TITLE
#159 enqueue scripts on block render

### DIFF
--- a/accordion-blocks.php
+++ b/accordion-blocks.php
@@ -59,6 +59,8 @@ class PB_Accordion_Blocks {
 		// Add settings page
 		add_action('admin_menu', array($this, 'add_settings_menu'));
 		add_action('admin_init', array($this, 'settings_api_init'));
+
+		add_action('render_block_pb/accordion-item', array($this, 'enqueue_assets_on_render'));
 	}
 
 
@@ -87,28 +89,41 @@ class PB_Accordion_Blocks {
 	 * Enqueue the block's assets for the frontend
 	 */
 	public function enqueue_frontend_assets() {
+		$min = (defined('SCRIPT_DEBUG') && SCRIPT_DEBUG) ? '' : '.min';
+
+		wp_register_script(
+			'pb-accordion-blocks-frontend-script',
+			plugins_url("js/accordion-blocks$min.js", __FILE__),
+			array('jquery'),
+			$this->plugin_version,
+			true
+		);
+
+		wp_register_style(
+			'pb-accordion-blocks-style',
+			plugins_url('build/index.css', __FILE__),
+			array(),
+			$this->plugin_version
+		);
+
 		$load_scripts_globally = $this->should_load_scripts_globally();
 
 		if ($load_scripts_globally || has_block('pb/accordion-item', get_the_ID())) {
-			$min = (defined('SCRIPT_DEBUG') && SCRIPT_DEBUG) ? '' : '.min';
-
-			wp_enqueue_script(
-				'pb-accordion-blocks-frontend-script',
-				plugins_url("js/accordion-blocks$min.js", __FILE__),
-				array('jquery'),
-				$this->plugin_version,
-				true
-			);
-
-			wp_enqueue_style(
-				'pb-accordion-blocks-style',
-				plugins_url('build/index.css', __FILE__),
-				array(),
-				$this->plugin_version
-			);
+			wp_enqueue_script('pb-accordion-blocks-frontend-script');
+			wp_enqueue_style('pb-accordion-blocks-style');	
 		}
 	}
 
+
+	/**
+	 * Always enqueue the registered assets when the block is rendered
+	 * fixes has_block not working in reusable blocks
+	 */
+	public function enqueue_assets_on_render($output) {
+		wp_enqueue_script('pb-accordion-blocks-frontend-script');
+		wp_enqueue_style('pb-accordion-blocks-style');	
+		return $output;
+	}
 
 
 	/**

--- a/block.json
+++ b/block.json
@@ -42,5 +42,7 @@
 		"anchor": true
 	},
 	"editorScript": "file:./build/index.js",
-	"editorStyle": "file:./build/index.css"
+	"editorStyle": "file:./build/index.css",
+	"script": "pb-accordion-blocks-frontend-script",
+	"style": "pb-accordion-blocks-style"
 }

--- a/block.json
+++ b/block.json
@@ -42,7 +42,5 @@
 		"anchor": true
 	},
 	"editorScript": "file:./build/index.js",
-	"editorStyle": "file:./build/index.css",
-	"script": "pb-accordion-blocks-frontend-script",
-	"style": "pb-accordion-blocks-style"
+	"editorStyle": "file:./build/index.css"
 }


### PR DESCRIPTION
Fixes #159 

Always register scripts, but only enqueue them on wp_enqueue_scripts in the existing if clause AND on block rendering via block-callback.

Note: I tried adding the script and style key to block.json but that just loads the assets on all pages.